### PR TITLE
Get module working by adding NODE_MODULE call in addon.cc

### DIFF
--- a/addon.cc
+++ b/addon.cc
@@ -24,3 +24,4 @@ extern "C" void init(Handle<Object> target) {
     NODE_SET_METHOD(target, "inspect", fi_inspect);
 }
 
+NODE_MODULE(function_inspector, init)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "bindings": "~1.0.0"
+    "bindings": "~1.1.0"
   },
   "devDependencies": {
     "tap": "~0.3.1"


### PR DESCRIPTION
Trying to use the module results in the error:

```
Symbol function_inspector_module not found.
```

I've added a call to `NODE_MODULE` which seems to fix the problem.
